### PR TITLE
Implement recursion and 2d-pose videos

### DIFF
--- a/deepfly/CLI/main.py
+++ b/deepfly/CLI/main.py
@@ -6,7 +6,14 @@ from pathlib import Path
 from deepfly.pose2d.drosophila import main as pose2d_main
 from deepfly.pose2d import ArgParse
 from ..GUI.Config import config
-from ..GUI.util.os_util import get_max_img_id, write_camera_order
+from ..GUI.util.os_util import get_max_img_id, write_camera_order, read_calib, read_camera_order
+from ..GUI.CameraNetwork import CameraNetwork
+from deepfly.pose2d.utils.osutils import find_leaf_recursive
+from ..GUI.util.os_util import *
+import cv2
+import matplotlib.pyplot as plt
+from tqdm import tqdm
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +31,26 @@ def main():
     setup_default_camera_ordering(args)  # custom function for convenience at the lab
     save_camera_ordering(args)           # write the camera ordering to file
 
-    #import pprint
-    #pprint.pprint(args)  # only used during dev
+    print('------------------------------------------------------')
+    print('POSE 2D ESTIMATION')
     pose2d_main(args)
+
+    print()
+    print('------------------------------------------------------')
+    print('POSE 2D VIDEOS')
+    if args.unlabeled_recursive:
+        unlabeled_folder_list = find_leaf_recursive(args.unlabeled)
+        unlabeled_folder_list = [path for path in unlabeled_folder_list if "images" in path]
+    else:
+        unlabeled_folder_list = [args.unlabeled]
+    for unlabeled_folder in unlabeled_folder_list:
+        max_img_id = get_max_img_id(unlabeled_folder)
+        args.num_images = min(max_img_id+1, args.num_images_max)
+        args.input_folder = unlabeled_folder
+        args.unlabeled = unlabeled_folder
+        make_pose2d_video(args)
+    
+    return args
 
 
 def setup_logger():
@@ -64,9 +88,8 @@ def clean_cli_args(args):
     args.input_folder = os.path.abspath(args.input_folder).rstrip('/')
     
     # Add custom constants
-    args.num_images = _num_images(args.input_folder, args.num_images_max)
+    #args.num_images = _num_images(args.input_folder, args.num_images_max)
     args.unlabeled = args.input_folder
-
     # Validate the provided camera ordering
     if args.camera_ids:
         ids = set(args.camera_ids)  # only keep unique ids
@@ -74,14 +97,14 @@ def clean_cli_args(args):
             raise ValueError('CAMERA-IDS argument must contain {} distinct ids, one per camera'.format(config['num_cameras']))
 
 
-def _num_images(input_folder, num_images_max):
-    """Compute the number of images to process based on:
-    - The number of images in the input folder (actually their maximal id), and
-    - The maximal number of images allowed to process
-    """
-    max_id = get_max_img_id(input_folder)
-    nb_in_folder = max_id + 1
-    return min(num_images_max, nb_in_folder)
+#def _num_images(input_folder, num_images_max):
+#    """Compute the number of images to process based on:
+#    - The number of images in the input folder (actually their maximal id), and
+#    - The maximal number of images allowed to process
+#    """
+#    max_id = get_max_img_id(input_folder)
+#    nb_in_folder = max_id + 1
+#    return min(num_images_max, nb_in_folder)
 
 
 def setup_default_camera_ordering(args):
@@ -97,10 +120,48 @@ def setup_default_camera_ordering(args):
             args.camera_ids = ordering
             return
 
+
 def save_camera_ordering(args):
     if args.camera_ids:
-        write_camera_order(os.path.join(args.input_folder, './df3d/'), args.camera_ids)
+        write_camera_order(os.path.join(args.input_folder, 'df3d/'), args.camera_ids)
         logger.debug('Camera ordering wrote to file in "{}"'.format(args.input_folder))
+
+
+def make_pose2d_video(args):
+
+    folder = os.path.join(args.input_folder, args.output_folder)
+    print('Looking for data in {}'.format(folder))
+    calib = read_calib(folder)
+    cid2cidread, cidread2cid = read_camera_order(folder)
+
+    camNet = CameraNetwork(image_folder=args.input_folder, cam_id_list=range(7), calibration=calib, 
+            cid2cidread=cid2cidread, num_images=args.num_images, output_folder=folder)
+        
+    def stack(img_id):
+            row1 = np.hstack([camNet[cam_id].plot_2d(img_id) for cam_id in [0, 1, 2]])
+            row2 = np.hstack([camNet[cam_id].plot_2d(img_id) for cam_id in [4, 5, 6]])
+            return np.vstack([row1, row2])
+
+    first_frame = stack(0)
+    shape = int(first_frame.shape[1]), int(first_frame.shape[0])
+
+    #plt.imshow(first_frame)
+
+    video_path = os.path.join(args.input_folder, args.output_folder, 'pose2d.mp4')
+    print('Saving pose2d video to: ' + video_path)
+    fourcc = cv2.VideoWriter_fourcc(*'MP4V')
+
+    fps = 30
+    video_writer = cv2.VideoWriter(video_path, fourcc, fps, shape)
+
+    for img_id in tqdm(range(args.num_images)):
+            grid = stack(img_id)
+            resized = cv2.resize(grid, shape)#(int(shape[0]), int(shape[1])))
+            rgb = cv2.cvtColor(resized, cv2.COLOR_BGR2RGB)
+            video_writer.write(rgb)
+
+    video_writer.release()
+    print('Done generating the pose2d video at {}\n'.format(video_path))
 
 
 if __name__ == '__main__':

--- a/deepfly/GUI/Camera.py
+++ b/deepfly/GUI/Camera.py
@@ -242,12 +242,9 @@ class Camera:
 
     def get_image(self, img_id, flip=False):
         try:
-            img = cv2.imread(
-                os.path.join(
-                    self.image_folder,
-                    "camera_{}_img_{:06}.jpg".format(self.cam_id_read, img_id),
-                )
-            )
+            image_path = os.path.join(self.image_folder,"camera_{}_img_{:06}.jpg".format(self.cam_id_read, img_id))
+            #print('Reading: ' + image_path)
+            img = cv2.imread(image_path)
             if img is None:
                 raise FileNotFoundError
         except FileNotFoundError:

--- a/deepfly/GUI/main.py
+++ b/deepfly/GUI/main.py
@@ -48,7 +48,7 @@ class DrosophAnnot(QWidget):
 
         if self.folder.endswith("/"):
             self.folder = self.folder[:-1]
-        self.folder_output = os.path.join(self.folder, './df3d/')
+        self.folder_output = os.path.join(self.folder, 'df3d/')
         if not os.path.exists(self.folder_output):
             print(self.folder_output)
             os.makedirs(self.folder_output)

--- a/deepfly/GUI/util/main_util.py
+++ b/deepfly/GUI/util/main_util.py
@@ -9,7 +9,6 @@ def button_set_width(btn, text=" ", margin=20):
 
 
 def calibrate_calc(drosophAnnot, min_img_id, max_img_id):
-
     from deepfly.GUI.util.os_util import read_calib
     calib = read_calib(config["calib_fine"])
     assert(calib is not None)

--- a/deepfly/GUI/util/os_util.py
+++ b/deepfly/GUI/util/os_util.py
@@ -2,23 +2,19 @@ import glob
 import os
 
 import numpy as np
-
+from pathlib import Path
 from ..Config import config
+import re
 
+image_name_re = re.compile(r'camera_0_img_([0-9]+).jpg')
 
 def get_max_img_id(path):
-    bound_low = 0
-    bound_high = 100000
-
-    curr = (bound_high + bound_low) // 2
-    while bound_high - bound_low > 1:
-        if image_exists_img_id(path, curr):
-            bound_low = curr
-        else:
-            bound_high = curr
-        curr = (bound_low + bound_high) // 2
-
-    return curr
+    files = os.listdir(path)
+    matches = (image_name_re.search(f) for f in files)
+    ids = [int(m.groups()[0]) for m in matches if m and m.groups()] 
+    m = max(ids) if ids else 0
+    print('Max id is {}'.format(m))
+    return m
 
 
 def image_exists_img_id(path, img_id):
@@ -75,6 +71,7 @@ def read_calib(folder):
 
 
 def parse_img_name(name):
+    #print('Parsing name: {}'.format(name))
     return int(name.split("_")[1]), int(name.split("_")[3].replace(".jpg", ""))
 
 

--- a/deepfly/GUI/util/os_util.py
+++ b/deepfly/GUI/util/os_util.py
@@ -8,6 +8,7 @@ import re
 
 image_name_re = re.compile(r'camera_0_img_([0-9]+).jpg')
 
+
 def get_max_img_id(path):
     files = os.listdir(path)
     matches = (image_name_re.search(f) for f in files)

--- a/deepfly/GUI/util/os_util.py
+++ b/deepfly/GUI/util/os_util.py
@@ -6,16 +6,21 @@ from pathlib import Path
 from ..Config import config
 import re
 
-image_name_re = re.compile(r'camera_0_img_([0-9]+).jpg')
-
 
 def get_max_img_id(path):
-    files = os.listdir(path)
-    matches = (image_name_re.search(f) for f in files)
-    ids = [int(m.groups()[0]) for m in matches if m and m.groups()] 
-    m = max(ids) if ids else 0
-    print('Max id is {}'.format(m))
-    return m
+    bound_low = 0
+    bound_high = 100000
+
+    curr = (bound_high + bound_low) // 2
+    while bound_high - bound_low > 1:
+        if image_exists_img_id(path, curr):
+            bound_low = curr
+        else:
+            bound_high = curr
+        curr = (bound_low + bound_high) // 2
+
+    return curr
+
 
 
 def image_exists_img_id(path, img_id):

--- a/deepfly/pose2d/ArgParse.py
+++ b/deepfly/pose2d/ArgParse.py
@@ -104,7 +104,7 @@ def add_arguments(parser):
     parser.add_argument(
         "--data-folder",
         dest="data_folder",
-        default="./data/drosophila/",
+        default="data/drosophila/",
         type=str,
         metavar="PATH",
         help="path to read data from",
@@ -112,7 +112,7 @@ def add_arguments(parser):
     parser.add_argument(
         "--output_folder",
         dest="output_folder",
-        default="./df3d/",
+        default="df3d/",
         type=str,
         metavar="PATH",
         help="path to place final results",

--- a/deepfly/pose2d/utils/osutils.py
+++ b/deepfly/pose2d/utils/osutils.py
@@ -26,8 +26,10 @@ def join(path, *paths):
 
 from pathlib import Path
 def find_leaf_recursive(path):
+    print('Recursive scan...')
     l = list()
     for root, dirs, files in os.walk(path):
         if Path(root).name == 'images':
+            print('Found working directory: {}'.format(root))
             l.append(root)
     return l

--- a/deepfly/pose2d/utils/osutils.py
+++ b/deepfly/pose2d/utils/osutils.py
@@ -24,9 +24,10 @@ def join(path, *paths):
     return os.path.join(path, *paths)
 
 
+from pathlib import Path
 def find_leaf_recursive(path):
     l = list()
     for root, dirs, files in os.walk(path):
-        if not dirs:
+        if Path(root).name == 'images':
             l.append(root)
     return l


### PR DESCRIPTION
This fixes the `--unlabeled-recursive` flag and implements pose-2d videos.

**[1]** To run in recursive mode:

```
export FOLDER=/ramdya-nas/CLC/190904_SS51017-tdTomGC6fopt/Fly3/CO2xzGG/

df3d-cli $FOLDER --unlabeled-recursive
```

I have also created a small test template in `./data`:

```
cd /home/semihg/workspace/DeepFly3D
source activate deepfly
df3d-cli ./data/recursive --unlabeled-recursive
```

**[2]** To limit the number of images to `100`:

```
df3d-cli $FOLDER --unlabeled-recursive -n 100
```

**[3]** The script will look for the subfolders named `images`, for instance:

```
$FOLDER/behData_001/images/
$FOLDER/behData_002/images/
```
And will create a subfolder `images/df3d/` containing the predictions and the video.

**[4]** To view all the generated videos in the NAS, you can use this command:

```
cd /ramdya-nas/CLC/190904_SS51017-tdTomGC6fopt/Fly3/CO2xzGG/
vlc `find . -name "*.mp4" | tr "\n" " "`
```

**[5]**  I launched the predictions and video generation recursively in `$FOLDER` Friday evening at 20:00. Hopefully the script will have completed without errors during the weekend and you can check the videos on monday. For extra clarity, here's the command I ran:

```
df3d-cli /ramdya-nas/CLC/190904_SS51017-tdTomGC6fopt/Fly3/CO2xzGG/ --unlabeled-recursive
```

If using the session `semihg`, you can connect to the running `tmux` using:

```
tmux a -t 1
```

**Remarks**
Fixing the path to `df3d` and the `--recursive-flag` was more involved than I would have thought. Mainly because in some part of the code the variable `output_folder` contains only the relative path `output_folder = df3d/` supposed to be relative to the `input_folder`, while in others it is set to the full path: `output_folder = path.join(input_folder, 'df3d')`.