### PR TITLE
fixed missing df3d directory that did not raise

### DIFF
--- a/deepfly/CLI/core_api.py
+++ b/deepfly/CLI/core_api.py
@@ -45,6 +45,7 @@ known_users = [
 
 def setup(input_folder, camera_ids, num_images_max):
     args = _get_pose2d_args(input_folder, camera_ids, num_images_max)
+    _create_df3d_folder(args)
     _setup_default_camera_ordering(args)
     _save_camera_ordering(args)
     return args
@@ -88,6 +89,11 @@ def _clean_args(args):
         if len(ids) != config['num_cameras']:
             raise ValueError('CAMERA-IDS argument must contain {} distinct ids, one per camera'.format(config['num_cameras']))
     return args
+
+
+def _create_df3d_folder(args):
+    os.makedirs(os.path.join(args.input_folder, "df3d"), exist_ok=True)
+
 
 def _setup_default_camera_ordering(args):
     """ This is a convenience function which automatically creates a default camera ordering for 

--- a/deepfly/GUI/util/os_util.py
+++ b/deepfly/GUI/util/os_util.py
@@ -60,10 +60,7 @@ def write_camera_order(folder, cidread2cid):
     assert (folder.endswith('df3d/') or folder.endswith('df3d'))
     path = os.path.join(folder, "cam_order")
     # print("Saving camera order {}: {}".format(path, cidread2cid))
-    try:
-        np.save(path, cidread2cid)
-    except:
-        return
+    np.save(path, cidread2cid)
 
 
 def read_calib(folder):


### PR DESCRIPTION
Fixes #12
The df3d folder is not created at the beginning of the cli. This issue remained unnoticed because all exceptions for saving the camera order were caught. 