### PR TITLE
fixed missing self

### DIFF
--- a/deepfly/GUI/CameraNetwork.py
+++ b/deepfly/GUI/CameraNetwork.py
@@ -103,7 +103,7 @@ class CameraNetwork:
                     self.dict_name = os.path.dirname(list(heatmap.keys())[10]) + "/"
 
             for cam_id in cam_id_list:
-                cam_id_read = cid2cidread[cam_id]
+                cam_id_read = self.cid2cidread[cam_id]
 
                 if heatmap is not None:# and type(heatmap) is np.core.memmap:
                     pred_cam = np.zeros(


### PR DESCRIPTION
When the `cid2cidread` argument is not set when the `CameraNetwork` constructor is called the class variable is set according to the `cam_id_list` in this [line](https://github.com/NeLy-EPFL/DeepFly3D/blob/6764e082a3291bb69afac7b35bf53af2406c61cf/deepfly/GUI/CameraNetwork.py#L50).
However, later in the constructor the argument variable is used instead of the class variable, which leads to the follwing Error: `TypeError: 'NoneType' object is not subscriptable`. (The default of the `cid2cidread` argument is `None`.) This pull request changes from the argument variable to the class variable.