### PR TITLE
Implement reprojection in 3d video

### DIFF
--- a/df3d/core.py
+++ b/df3d/core.py
@@ -295,7 +295,8 @@ class Core:
             private_cache[cam_id] = smooth_pose2d(cam.points2d)
         return private_cache[cam_id]
 
-    def plot_2d(self, cam_id, img_id, with_corrections=False, smooth=False, joints=[]):
+    def plot_2d(self, cam_id, img_id, with_corrections=False,
+                smooth=False, joints=[], reprojection=False):
         """Plots the 2d pose estimation results.
 
         Parameters:
@@ -311,11 +312,15 @@ class Core:
         from pyba.config import df3d_bones, df3d_colors
 
         if with_corrections:
-            pts2d = self.corrected_points2d(cam_id, img_id)
+            pts = self.corrected_points2d(cam_id, img_id)
         else:
-            pts2d = None
+            pts = None
+
+        if reprojection:
+            pts = np.copy(self.camNet.points3d)
+
         return self.camNet[cam_id].plot_2d(
-            img_id, points2d=pts2d, bones=df3d_bones, colors=df3d_colors
+            img_id, points=pts, bones=df3d_bones, colors=df3d_colors
         )
 
     def get_image(self, cam_id, img_id):

--- a/df3d/core.py
+++ b/df3d/core.py
@@ -311,17 +311,17 @@ class Core:
         """
         from pyba.config import df3d_bones, df3d_colors
 
-        if with_corrections:
-            pts = self.corrected_points2d(cam_id, img_id)
-        else:
-            pts = None
+        if with_corrections and reprojection:
+            raise ValueError("'with_corrections' and 'reprojection' "
+                             "cannot both be set to True")
 
+        cam = self.camNet[cam_id]
         if reprojection:
-            pts = np.copy(self.camNet.points3d)
-
-        return self.camNet[cam_id].plot_2d(
-            img_id, points=pts, bones=df3d_bones, colors=df3d_colors
-        )
+            return cam.plot_reprojections(img_id, self.camNet.points3d,
+                                          bones=df3d_bones, colors=df3d_colors)
+        pts2d = self.corrected_points2d(cam_id, img_id) if with_corrections else None
+        return cam.plot_2d(img_id, points2d=pts2d,
+                           bones=df3d_bones, colors=df3d_colors)
 
     def get_image(self, cam_id, img_id):
         """Returns the img_id image from cam_id camera."""

--- a/df3d/video.py
+++ b/df3d/video.py
@@ -110,17 +110,17 @@ def _make_video(video_path, imgs, fps=default_fps):
 
 def _resize(current_shape, new_width):
     width, height = current_shape
-    ratio = new_width / width;
+    ratio = new_width / width
     return (int(width * ratio), int(height * ratio))
 
 
-def _compute_2d_img(plot_2d, img_id, cam_id):
+def _compute_2d_img(plot_2d, img_id, cam_id, reprojection=True):
     """Uses plot_2d to generate an image and resizes it using cv2.
 
     Returns:
     A numpy array containing the resized image.
     """
-    img = plot_2d(cam_id, img_id, smooth=True)
+    img = plot_2d(cam_id, img_id, smooth=True, reprojection=reprojection)
     img = cv2.resize(img, (img2d_aspect[0]*img3d_dpi, img2d_aspect[1]*img3d_dpi))
     return img
 


### PR DESCRIPTION
In order to implement the re-projection for the 3d video, instead of having the 2d video play on top of the 3d plot, the plot_2d method of the Core class was modified to take an extra boolean argument that distinguishes between plotting the re-projection of the 3d points and plotting 2d points. If reprojection is true it passes the 3d points from the camNet attribute of the class to the plot_2d method of the Camera class as modified here (https://github.com/semihgunel/PyBundleAdjustment/pull/2#issue-3256815059), which is able to handle the re-projection and the plotting of 2d points. The video.py file was also modified with the _compute_2d_img also taking a reprojection argument (by default true) that it passes to the Core.plot_2d method.